### PR TITLE
fix(shared): exports追加#42

### DIFF
--- a/src/app/chat/chat.module.ts
+++ b/src/app/chat/chat.module.ts
@@ -7,7 +7,6 @@ import { SpeechComponent } from './speech/speech.component';
 import { InputComponent } from './input/input.component';
 
 import { SharedModule } from '../shared/shared.module';
-// import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TextFieldModule } from '@angular/cdk/text-field';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -18,8 +17,6 @@ import { MatInputModule } from '@angular/material/input';
     CommonModule,
     ChatRoutingModule,
     SharedModule,
-    // FormsModule,
-    // ReactiveFormsModule,
     TextFieldModule,
     MatFormFieldModule,
     MatInputModule,

--- a/src/app/chat/chat.module.ts
+++ b/src/app/chat/chat.module.ts
@@ -7,7 +7,7 @@ import { SpeechComponent } from './speech/speech.component';
 import { InputComponent } from './input/input.component';
 
 import { SharedModule } from '../shared/shared.module';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+// import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TextFieldModule } from '@angular/cdk/text-field';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -18,8 +18,8 @@ import { MatInputModule } from '@angular/material/input';
     CommonModule,
     ChatRoutingModule,
     SharedModule,
-    FormsModule,
-    ReactiveFormsModule,
+    // FormsModule,
+    // ReactiveFormsModule,
     TextFieldModule,
     MatFormFieldModule,
     MatInputModule,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -13,5 +13,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     FormsModule,
     ReactiveFormsModule,
   ],
+  exports: [FormsModule, ReactiveFormsModule],
 })
 export class SharedModule {}


### PR DESCRIPTION
fix #42 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- sharedModuleのexportsに下記を追加。

> FromModule

> ReactiveFormsModule



- chatModuleで読み込んでいたモジュールを削除。

> import { FormsModule, ReactiveFormsModule } from '@angular/forms';



### イメージ
![image](https://user-images.githubusercontent.com/55618591/80051891-4d5e6380-8554-11ea-9cbd-03fc49987dab.png)
